### PR TITLE
Drastically improve parser performance

### DIFF
--- a/BushelLanguage/BushelLanguageTests/TermNameSearchingTests.swift
+++ b/BushelLanguage/BushelLanguageTests/TermNameSearchingTests.swift
@@ -25,17 +25,20 @@ class TermNameSearchingTests: XCTestCase {
     }
     
     func test_complexSearch_matchesSingleWordAtBeginning() {
-        let (termString, termName) = termNames(["one", "two"]).findComplexTermName(in: source)
+        let table = buildTraversalTable(for: termNames(["one", "two"]))
+        let (termString, termName) = findComplexTermName(from: table, in: source)
         XCTAssertEqual(termString, "one")
         XCTAssertEqual(termName, TermName("one"))
     }
     func test_complexSearch_doesNotMatchSingleWordBeyondFirst() {
-        let (termString, termName) = termNames(["two", "three"]).findComplexTermName(in: source)
+        let table = buildTraversalTable(for: termNames(["two", "three"]))
+        let (termString, termName) = findComplexTermName(from: table, in: source)
         XCTAssertEqual(termString, "")
         XCTAssertEqual(termName, nil)
     }
     func test_complexSearch_matchesMultiWordAtBeginning() {
-        let (termString, termName) = termNames(["one two three", "two", "three", "a"]).findComplexTermName(in: source)
+        let table = buildTraversalTable(for: termNames(["one two three", "two", "three", "a"]))
+        let (termString, termName) = findComplexTermName(from: table, in: source)
         XCTAssertEqual(termString, "one two three")
         XCTAssertEqual(termName, TermName("one two three"))
     }

--- a/BushelLanguage/BushelLanguageTests/TermNameSearchingTests.swift
+++ b/BushelLanguage/BushelLanguageTests/TermNameSearchingTests.swift
@@ -4,9 +4,43 @@ import Bushel
 
 // Protip: ⌥⇧⌘← to fold all methods
 
+private let sourceOrig = "one two three a b c"
+private let source = sourceOrig[...]
+
 class TermNameSearchingTests: XCTestCase {
     
-    func test_searchPerformace_alwaysSuccess_shortWords() {
+    func termNames(_ strings: [String]) -> Set<TermName> {
+        Set(strings.map { TermName($0) })
+    }
+    
+    func test_simpleSearch_matchesAtBeginning() {
+        let (termString, termName) = termNames(["one", "two"]).findSimpleTermName(in: source)
+        XCTAssertEqual(termString, "one")
+        XCTAssertEqual(termName, TermName("one"))
+    }
+    func test_simpleSearch_doesNotMatchBeyondFirst() {
+        let (termString, termName) = termNames(["two", "three"]).findSimpleTermName(in: source)
+        XCTAssertEqual(termString, "")
+        XCTAssertEqual(termName, nil)
+    }
+    
+    func test_complexSearch_matchesSingleWordAtBeginning() {
+        let (termString, termName) = termNames(["one", "two"]).findComplexTermName(in: source)
+        XCTAssertEqual(termString, "one")
+        XCTAssertEqual(termName, TermName("one"))
+    }
+    func test_complexSearch_doesNotMatchSingleWordBeyondFirst() {
+        let (termString, termName) = termNames(["two", "three"]).findComplexTermName(in: source)
+        XCTAssertEqual(termString, "")
+        XCTAssertEqual(termName, nil)
+    }
+    func test_complexSearch_matchesMultiWordAtBeginning() {
+        let (termString, termName) = termNames(["one two three", "two", "three", "a"]).findComplexTermName(in: source)
+        XCTAssertEqual(termString, "one two three")
+        XCTAssertEqual(termName, TermName("one two three"))
+    }
+    
+    func testPerformence_simpleSearch_shortWords() {
         let source = String(
             repeating: "if let let end if to on let me to if on if to let let end end to on ", // 20 words
             count: 10
@@ -21,7 +55,7 @@ class TermNameSearchingTests: XCTestCase {
         
         measure {
             var source = Substring(source)
-            while case (let termString, _?) = terms.findTermName(in: source) {
+            while case (let termString, _?) = terms.findSimpleTermName(in: source) {
                 source.removeFirst(termString.count)
             }
         }

--- a/BushelLanguage/Language Modules/SourceParser.swift
+++ b/BushelLanguage/Language Modules/SourceParser.swift
@@ -913,25 +913,25 @@ extension SourceParser {
     }
     
     private func eatLineCommentMarker() -> Bool {
-        let result = lineCommentMarkers.findTermName(in: source)
+        let result = lineCommentMarkers.findSimpleTermName(in: source)
         source.removeFirst(result.termString.count)
         return result.termName != nil
     }
     
     private func eatBlockCommentBeginMarker() -> Bool {
-        let result = blockCommentMarkers.map { $0.begin }.findTermName(in: source)
+        let result = blockCommentMarkers.map { $0.begin }.findSimpleTermName(in: source)
         source.removeFirst(result.termString.count)
         return result.termName != nil
     }
     
     private func eatBlockCommentEndMarker() -> Bool {
-        let result = blockCommentMarkers.map { $0.end }.findTermName(in: source)
+        let result = blockCommentMarkers.map { $0.end }.findSimpleTermName(in: source)
         source.removeFirst(result.termString.count)
         return result.termName != nil
     }
     
     private func eatKeyword() -> TermName? {
-        let result = Array(keywords.keys).findTermName(in: source)
+        let result = Array(keywords.keys).findComplexTermName(in: source)
         guard let termName = result.termName else {
             return nil
         }
@@ -942,14 +942,14 @@ extension SourceParser {
     }
     
     private func findPrefixOperator() -> (termName: TermName, operator: UnaryOperation)? {
-        let result = Array(prefixOperators.keys).findTermName(in: source)
+        let result = Array(prefixOperators.keys).findSimpleTermName(in: source)
         return result.termName.map { name in
             (termName: name, operator: prefixOperators[name]!)
         }
     }
     
     private func eatPrefixOperator() {
-        let result = Array(prefixOperators.keys).findTermName(in: source)
+        let result = Array(prefixOperators.keys).findSimpleTermName(in: source)
         guard result.termName != nil else {
             return
         }
@@ -959,14 +959,14 @@ extension SourceParser {
     }
     
     private func findPostfixOperator() -> (termName: TermName, operator: UnaryOperation)? {
-        let result = Array(postfixOperators.keys).findTermName(in: source)
+        let result = Array(postfixOperators.keys).findSimpleTermName(in: source)
         return result.termName.map { name in
             (termName: name, operator: postfixOperators[name]!)
         }
     }
     
     private func eatPostfixOperator() {
-        let result = Array(postfixOperators.keys).findTermName(in: source)
+        let result = Array(postfixOperators.keys).findSimpleTermName(in: source)
         guard result.termName != nil else {
             return
         }
@@ -976,14 +976,14 @@ extension SourceParser {
     }
     
     private func findBinaryOperator() -> (termName: TermName, operator: BinaryOperation)? {
-        let result = Array(binaryOperators.keys).findTermName(in: source)
+        let result = Array(binaryOperators.keys).findSimpleTermName(in: source)
         return result.termName.map { name in
             (termName: name, operator: binaryOperators[name]!)
         }
     }
     
     private func eatBinaryOperator() {
-        let result = Array(binaryOperators.keys).findTermName(in: source)
+        let result = Array(binaryOperators.keys).findSimpleTermName(in: source)
         guard result.termName != nil else {
             return
         }
@@ -994,7 +994,7 @@ extension SourceParser {
     }
     
     private func eatStringBeginMarker() -> (begin: TermName, end: TermName)? {
-        let result = stringMarkers.map { $0.begin }.findTermName(in: source)
+        let result = stringMarkers.map { $0.begin }.findSimpleTermName(in: source)
         guard let termName = result.termName else {
             return nil
         }
@@ -1005,7 +1005,7 @@ extension SourceParser {
     }
     
     private func eatExpressionGroupingBeginMarker() -> (begin: TermName, end: TermName)? {
-        let result = expressionGroupingMarkers.map { $0.begin }.findTermName(in: source)
+        let result = expressionGroupingMarkers.map { $0.begin }.findSimpleTermName(in: source)
         guard let termName = result.termName else {
             return nil
         }
@@ -1014,7 +1014,7 @@ extension SourceParser {
     }
     
     private func eatListBeginMarker() -> (begin: TermName, end: TermName, itemSeparators: [TermName])? {
-        let result = listMarkers.map { $0.begin }.findTermName(in: source)
+        let result = listMarkers.map { $0.begin }.findSimpleTermName(in: source)
         guard let termName = result.termName else {
             return nil
         }
@@ -1023,7 +1023,7 @@ extension SourceParser {
     }
     
     private func eatRecordBeginMarker() -> (begin: TermName, end: TermName, itemSeparators: [TermName], keyValueSeparators: [TermName])? {
-        let result = recordMarkers.map { $0.begin }.findTermName(in: source)
+        let result = recordMarkers.map { $0.begin }.findSimpleTermName(in: source)
         guard let termName = result.termName else {
             return nil
         }
@@ -1032,7 +1032,7 @@ extension SourceParser {
     }
     
     private func eatListAndRecordBeginMarker() -> (begin: TermName, end: TermName, itemSeparators: [TermName], keyValueSeparators: [TermName])? {
-        let result = listAndRecordMarkers.map { $0.begin }.findTermName(in: source)
+        let result = listAndRecordMarkers.map { $0.begin }.findSimpleTermName(in: source)
         guard let termName = result.termName else {
             return nil
         }
@@ -1041,7 +1041,7 @@ extension SourceParser {
     }
     
     private func findExpressionEndKeyword() -> Bool {
-        if case (_, _?)? = awaitingExpressionEndKeywords.last.map({ Array($0) })?.findTermName(in: source) ?? nil {
+        if case (_, _?)? = awaitingExpressionEndKeywords.last.map({ Array($0) })?.findComplexTermName(in: source) ?? nil {
             return true
         }
         return false

--- a/BushelLanguage/Language Modules/SourceParser.swift
+++ b/BushelLanguage/Language Modules/SourceParser.swift
@@ -997,7 +997,7 @@ extension SourceParser {
     }
     
     private func eatBinaryOperator() {
-        let result = findComplexTermName(from: postfixOperatorsTraversalTable, in: source)
+        let result = findComplexTermName(from: binaryOperatorsTraversalTable, in: source)
         guard result.termName != nil else {
             return
         }

--- a/BushelLanguage/Utilities/Terminology.swift
+++ b/BushelLanguage/Utilities/Terminology.swift
@@ -34,47 +34,45 @@ public func findComplexTermName(from dictionary: TermNameTraversalTable, in sour
     // Advance endIndex to 1 past the end of each word in the line until
     // a term name matches those words, or we reach the end of the line.
     var endIndex = line.startIndex
+    var largestMatchEndIndex = endIndex
     while true {
-        let subsequentWordsStartIndex = endIndex
+        func largestMatch() -> (termString: Substring, termName: TermName?) {
+            let matchedSource = line[..<largestMatchEndIndex]
+            return (matchedSource, matchedSource.isEmpty ? nil : TermName(matchedSource))
+        }
+        
         endIndex =
             line[endIndex...]
             .drop(while: { $0.isWhitespace })
             .drop(while: { !$0.isWhitespace })
             .startIndex
+        
         guard let subsequentWords = dictionary[TermName(line[..<endIndex])] else {
-            // There are no possible longer matches of what we've already matched.
-            // Return the last match (or no match if there is no last match).
-            let matchedSource = line[..<subsequentWordsStartIndex]
-            return (matchedSource, matchedSource.isEmpty ? nil : TermName(matchedSource))
+            // There are no possible larger matches than whatever we've already matched.
+            return largestMatch()
         }
+        
         if subsequentWords.contains(TermName([])) {
             // Can match this iteration.
-            if subsequentWords.count == 1 || endIndex == line.endIndex {
-                // Exact match with no possible longer matches.
-                let matchedSource = line[..<endIndex]
-                return (matchedSource, TermName(matchedSource))
-            } else {
-                // We could have matched this iteration,
-                // but longer matches are also possible.
-                continue
+            largestMatchEndIndex = endIndex
+            
+            if subsequentWords.count == 1 {
+                // No possible larger matches.
+                return largestMatch()
             }
-        } else {
-            // Cannot possibly match this iteration.
-            if endIndex == line.endIndex {
-                // No matches possible.
-                return (line[..<line.startIndex], nil)
-            } else {
-                // Possible match in future iteration.
-                continue
-            }
+            
+            // If we get here, a larger match in a future iteration is possible.
+            // (If we find that there are no larger matches, however,
+            // this match will be used.)
         }
+        
+        if endIndex == line.endIndex {
+            // No future iterations possible.
+            return largestMatch()
+        }
+        
+        // If we get here, there is a possible match in a future iteration.
     }
-    
-    // TMR: This is slow because we are not backing out early enough.
-    //      Need to ideally filter the set word by word, and abort
-    //      the moment the set reaches 1 matching element, or 0 elements.
-    //      Might use hash table to expedite reaching that new set (precompute them all).
-    // ["a": ["b", "c", "b c"], "a b": ["", "c"]]
 }
     
 public func buildTraversalTable<TermNames: Collection>(

--- a/BushelLanguage/Utilities/Terminology.swift
+++ b/BushelLanguage/Utilities/Terminology.swift
@@ -2,6 +2,44 @@ import Bushel
 
 public extension Collection where Element == TermName {
     
+    func findSimpleTermName(in source: Substring) -> (termString: Substring, termName: TermName?) {
+        let word = source.removingLeadingWhitespace().prefix(while: { !$0.isWhitespace })
+        let termName = TermName(word)
+        if self.contains(termName) {
+            return (word, termName)
+        } else {
+            return (source[..<source.startIndex], nil)
+        }
+    }
+    
+    func findComplexTermName(in source: Substring) -> (termString: Substring, termName: TermName?) {
+        let line = source
+            .removingLeadingWhitespace()
+            .prefix(while: { !$0.isNewline })
+            .removingTrailingWhitespace()
+        
+        // Advance endIndex to 1 past the end of each word in the line until
+        // a term name matches those words, or we reach the end of the line.
+        var endIndex = line.startIndex
+        repeat {
+            endIndex =
+                line[endIndex...]
+                .drop(while: { $0.isWhitespace })
+                .drop(while: { !$0.isWhitespace })
+                .startIndex
+        } while !self.contains(TermName(line[..<endIndex])) && endIndex != line.endIndex
+        
+        // Make a final judgment on whether we have matched a term name.
+        let termString = line[..<endIndex]
+        let termName = TermName(termString)
+        if self.contains(termName) {
+            return (termString, termName)
+        } else {
+            return (line[..<line.startIndex], nil)
+        }
+    }
+    
+    /*
     func findTermName(in source: Substring) -> (termString: Substring, termName: TermName?) {
         let line = source.prefix(while: { !$0.isNewline })
         guard let lastNonWhitespace = line.lastIndex(where: { !$0.isWhitespace }) else {
@@ -49,5 +87,6 @@ public extension Collection where Element == TermName {
         
         return (termString, termName)
     }
+    */
     
 }

--- a/BushelLanguage/Utilities/Terminology.swift
+++ b/BushelLanguage/Utilities/Terminology.swift
@@ -3,90 +3,97 @@ import Bushel
 public extension Collection where Element == TermName {
     
     func findSimpleTermName(in source: Substring) -> (termString: Substring, termName: TermName?) {
-        let word = source.removingLeadingWhitespace().prefix(while: { !$0.isWhitespace })
+        func noMatch() -> (termString: Substring, termName: TermName?) {
+            (source[..<source.startIndex], nil)
+        }
+        if source.isEmpty {
+            return noMatch()
+        }
+        var word = source.removingLeadingWhitespace().prefix(while: { !$0.isWordBreaking })
+        if word.isEmpty {
+            word = source[...source.startIndex]
+        }
         let termName = TermName(word)
         if self.contains(termName) {
             return (word, termName)
         } else {
-            return (source[..<source.startIndex], nil)
+            return noMatch()
         }
     }
-    
-    func findComplexTermName(in source: Substring) -> (termString: Substring, termName: TermName?) {
-        let line = source
-            .removingLeadingWhitespace()
-            .prefix(while: { !$0.isNewline })
-            .removingTrailingWhitespace()
-        
-        // Advance endIndex to 1 past the end of each word in the line until
-        // a term name matches those words, or we reach the end of the line.
-        var endIndex = line.startIndex
-        repeat {
-            endIndex =
-                line[endIndex...]
-                .drop(while: { $0.isWhitespace })
-                .drop(while: { !$0.isWhitespace })
-                .startIndex
-        } while !self.contains(TermName(line[..<endIndex])) && endIndex != line.endIndex
-        
-        // Make a final judgment on whether we have matched a term name.
-        let termString = line[..<endIndex]
-        let termName = TermName(termString)
-        if self.contains(termName) {
-            return (termString, termName)
-        } else {
-            return (line[..<line.startIndex], nil)
-        }
-    }
-    
-    /*
-    func findTermName(in source: Substring) -> (termString: Substring, termName: TermName?) {
-        let line = source.prefix(while: { !$0.isNewline })
-        guard let lastNonWhitespace = line.lastIndex(where: { !$0.isWhitespace }) else {
-            // Only whitespace
-            return (source[source.startIndex..<source.startIndex], nil)
-        }
-        
-        let initialTermName = TermName(String(source[...lastNonWhitespace]))
-        let initialWords = initialTermName.words
-        
-        var words: [String] = []
-        var matches: [TermName?] = []
-        var candidates = [TermName](self) // Just an optimization
-        
-        for word in initialWords {
-            words.append(word)
-            let termName = TermName(words)
-            
-            matches.append(self.contains(termName) ? termName : nil)
-            
-            candidates.removeAll { (candidate: TermName) -> Bool in
-                candidate.words.count < words.count || candidate.words[..<words.count] != ArraySlice(words)
-            }
-            if candidates.isEmpty {
-                // No more-specific term name can be matched
-                break
-            }
-        }
-        
-        guard let termName = matches.last(where: { $0 != nil }) as? TermName else {
-            // No match
-            return (source[source.startIndex..<source.startIndex], nil)
-        }
-        
-        var termString = line
-        
-        let wordsRemovedCount = initialWords.count - termName.words.count
-        let wordsRemoved = initialWords.suffix(wordsRemovedCount)
-        
-        for word in wordsRemoved.reversed() {
-            termString.removeTrailingWhitespace()
-            termString.removeLast(word.count)
-        }
-        termString.removeTrailingWhitespace()
-        
-        return (termString, termName)
-    }
-    */
     
 }
+
+public typealias TermNameTraversalTable = [TermName : [TermName]]
+
+public func findComplexTermName(from dictionary: TermNameTraversalTable, in source: Substring) -> (termString: Substring, termName: TermName?) {
+    let line = source
+        .removingLeadingWhitespace()
+        .prefix(while: { !$0.isNewline })
+        .removingTrailingWhitespace()
+    
+    // Advance endIndex to 1 past the end of each word in the line until
+    // a term name matches those words, or we reach the end of the line.
+    var endIndex = line.startIndex
+    while true {
+        let subsequentWordsStartIndex = endIndex
+        endIndex =
+            line[endIndex...]
+            .drop(while: { $0.isWhitespace })
+            .drop(while: { !$0.isWhitespace })
+            .startIndex
+        guard let subsequentWords = dictionary[TermName(line[..<endIndex])] else {
+            // There are no possible longer matches of what we've already matched.
+            // Return the last match (or no match if there is no last match).
+            let matchedSource = line[..<subsequentWordsStartIndex]
+            return (matchedSource, matchedSource.isEmpty ? nil : TermName(matchedSource))
+        }
+        if subsequentWords.contains(TermName([])) {
+            // Can match this iteration.
+            if subsequentWords.count == 1 || endIndex == line.endIndex {
+                // Exact match with no possible longer matches.
+                let matchedSource = line[..<endIndex]
+                return (matchedSource, TermName(matchedSource))
+            } else {
+                // We could have matched this iteration,
+                // but longer matches are also possible.
+                continue
+            }
+        } else {
+            // Cannot possibly match this iteration.
+            if endIndex == line.endIndex {
+                // No matches possible.
+                return (line[..<line.startIndex], nil)
+            } else {
+                // Possible match in future iteration.
+                continue
+            }
+        }
+    }
+    
+    // TMR: This is slow because we are not backing out early enough.
+    //      Need to ideally filter the set word by word, and abort
+    //      the moment the set reaches 1 matching element, or 0 elements.
+    //      Might use hash table to expedite reaching that new set (precompute them all).
+    // ["a": ["b", "c", "b c"], "a b": ["", "c"]]
+}
+    
+public func buildTraversalTable<TermNames: Collection>(
+    for termNames: TermNames
+) -> TermNameTraversalTable
+where TermNames.Element == TermName
+{
+    var traversalTable: TermNameTraversalTable = [:]
+    for termName in termNames {
+        for wordIndex in termName.words.indices {
+            let currentWords = TermName(Array(termName.words[...wordIndex]))
+            let subsequentWords = TermName(Array(termName.words[(wordIndex + 1)...]))
+            if traversalTable.keys.contains(currentWords) {
+                traversalTable[currentWords]!.append(subsequentWords)
+            } else {
+                traversalTable[currentWords] = [subsequentWords]
+            }
+        }
+    }
+    return traversalTable
+}
+

--- a/BushelLanguageTestingTools/FormatterTestCase.swift
+++ b/BushelLanguageTestingTools/FormatterTestCase.swift
@@ -10,7 +10,7 @@ open class FormatterTestCase: XCTestCase {
             do {
                 program = try languageModule.parser().parse(source: source)
             } catch {
-                return XCTFail("Initial parsing should succeed for \(name)")
+                return XCTFail("Initial parsing should succeed for \(name); error: \(error)")
             }
             let formattedSource = languageModule.formatter().format(program.ast)
             
@@ -33,7 +33,7 @@ open class FormatterTestCase: XCTestCase {
             do {
                 program = try languageModule.parser().parse(source: source)
             } catch {
-                return XCTFail("Initial parsing should succeed for \(name)")
+                return XCTFail("Initial parsing should succeed for \(name); error: \(error)")
             }
             let formattedSource = languageModule.formatter().format(program.ast)
             

--- a/BushelRT/Built-in Functions/Builtin.swift
+++ b/BushelRT/Built-in Functions/Builtin.swift
@@ -43,34 +43,6 @@ final class Builtin {
         }
     }
     
-    func newClass(_ typedUID: TypedTermUID) -> RT_Object {
-        return RT_Class(value: rt.type(forUID: typedUID))
-    }
-    
-    func newList() -> RT_Object {
-        return RT_List(contents: [])
-    }
-    
-    func newRecord() -> RT_Object {
-        return RT_Record(contents: [:])
-    }
-    
-    func newArgumentRecord() -> RT_Private_ArgumentRecord {
-        return RT_Private_ArgumentRecord()
-    }
-    
-    func addToList(_ list: RT_List, _ value: RT_Object) {
-        list.add(value)
-    }
-    
-    func addToRecord(_ record: RT_Record, _ key: RT_Object, _ value: RT_Object) {
-        record.add(key: key, value: value)
-    }
-    
-    func addToArgumentRecord(_ record: RT_Private_ArgumentRecord, _ typedUID: TypedTermUID, _ value: RT_Object) {
-        record.contents[typedUID] = value
-    }
-    
     func getSequenceLength(_ sequence: RT_Object) throws -> Int64 {
         do {
             let length = try sequence.property(rt.property(forUID: TypedTermUID(PropertyUID.Sequence_length))) as? RT_Numeric
@@ -240,17 +212,7 @@ final class Builtin {
         return function
     }
     
-    func runCommand(_ command: CommandInfo, _ arguments: RT_Private_ArgumentRecord, _ target: RT_Object) throws -> RT_Object {
-        return try run(command: command, arguments: self.arguments(from: arguments), target: target)
-    }
-    
-    private func arguments(from record: RT_Private_ArgumentRecord) -> [ParameterInfo : RT_Object] {
-        [ParameterInfo : RT_Object](uniqueKeysWithValues:
-            record.contents.map { (key: ParameterInfo($0.key.uid), value: $0.value) }
-        )
-    }
-    
-    private func run(command: CommandInfo, arguments: [ParameterInfo : RT_Object], target: RT_Object) throws -> RT_Object {
+    func run(command: CommandInfo, arguments: [ParameterInfo : RT_Object], target: RT_Object) throws -> RT_Object {
         var argumentsWithoutDirect = arguments
         argumentsWithoutDirect.removeValue(forKey: ParameterInfo(.direct))
         

--- a/BushelRT/Built-in Functions/Builtin.swift
+++ b/BushelRT/Built-in Functions/Builtin.swift
@@ -143,37 +143,6 @@ final class Builtin {
         }() as RT_Object
     }
     
-    func newSpecifier0(_ parent: RT_Object?, _ typedUID: TypedTermUID, _ kind: RT_Specifier.Kind) -> RT_Specifier {
-        let newSpecifier: RT_Specifier
-        if kind == .property {
-            newSpecifier = RT_Specifier(parent: parent, type: nil, property: rt.property(forUID: typedUID), data: [], kind: .property)
-        } else {
-            let type = rt.type(forUID: typedUID)
-            newSpecifier = RT_Specifier(parent: parent, type: type, data: [], kind: kind)
-        }
-        return newSpecifier
-    }
-    func newSpecifier1(_ parent: RT_Object?, _ typedUID: TypedTermUID, _ kind: RT_Specifier.Kind, _ data1: RT_Object) -> RT_Specifier {
-        let newSpecifier: RT_Specifier
-        if kind == .property {
-            newSpecifier = RT_Specifier(parent: parent, type: nil, property: rt.property(forUID: typedUID), data: [data1], kind: .property)
-        } else {
-            let type = rt.type(forUID: typedUID)
-            newSpecifier = RT_Specifier(parent: parent, type: type, data: [data1], kind: kind)
-        }
-        return newSpecifier
-    }
-    func newSpecifier2(_ parent: RT_Object?, _ typedUID: TypedTermUID, _ kind: RT_Specifier.Kind, _ data1: RT_Object, _ data2: RT_Object) -> RT_Specifier {
-        let newSpecifier: RT_Specifier
-        if kind == .property {
-            newSpecifier = RT_Specifier(parent: parent, type: nil, property: rt.property(forUID: typedUID), data: [data1, data2], kind: .property)
-        } else {
-            let type = rt.type(forUID: typedUID)
-            newSpecifier = RT_Specifier(parent: parent, type: type, data: [data1, data2], kind: kind)
-        }
-        return newSpecifier
-    }
-    
     func newTestSpecifier(_ operation: BinaryOperation, _ lhs: RT_Object, _ rhs: RT_Object) -> RT_Object {
         return RT_TestSpecifier(operation: operation, lhs: lhs, rhs: rhs)
     }
@@ -192,19 +161,6 @@ final class Builtin {
         } catch {
             try throwError(message: "error evaluating specifier ‘\(specifier)’: \(error.localizedDescription)")
         }
-    }
-    
-    func newScript(_ name: String) -> RT_Object {
-        return RT_Script(name: name)
-    }
-    
-    func newFunction(_ commandInfo: CommandInfo, _ functionExpression: Expression, _ script: RT_Script?) -> RT_Object {
-        let script = script ?? rt.topScript
-        
-        let function = RT_Function(rt, functionExpression)
-        script.dynamicFunctions[commandInfo] = function
-        
-        return function
     }
     
     func run(command: CommandInfo, arguments: [ParameterInfo : RT_Object], target: RT_Object) throws -> RT_Object {

--- a/BushelRT/Built-in Functions/Builtin.swift
+++ b/BushelRT/Built-in Functions/Builtin.swift
@@ -71,8 +71,8 @@ final class Builtin {
         }() ?? RT_Null.null
     }
     
-    func binaryOp(_ operation: BinaryOperation, _ lhs: RT_Object, _ rhs: RT_Object) -> RT_Object {
-        return { () -> RT_Object? in
+    func binaryOp(_ operation: BinaryOperation, _ lhs: RT_Object, _ rhs: RT_Object) throws -> RT_Object {
+        return try { () -> RT_Object? in
             switch operation {
             case .or:
                 return lhs.or(rhs)
@@ -119,14 +119,9 @@ final class Builtin {
             case .concatenate:
                 return lhs.concatenating(rhs) ?? rhs.concatenated(to: lhs)
             case .coerce:
-                return lhs.coercing(to: rhs)
+                return try lhs.coercing(to: rhs)
             }
         }() ?? RT_Null.null
-    }
-    
-    func coerce(_ object: RT_Object, to type: TypeInfo) -> RT_Object {
-        // TODO: Should throw error when not coercible
-        return object.coerce(to: type) ?? RT_Null.null
     }
     
     func getResource(_ term: ResourceTerm) -> RT_Object {

--- a/BushelRT/Built-in Functions/Builtin.swift
+++ b/BushelRT/Built-in Functions/Builtin.swift
@@ -6,11 +6,6 @@ final class Builtin {
     var rt = Runtime()
     lazy var stack = ProgramStack(rt)
     
-    public typealias Pointer = UnsafeMutableRawPointer
-    public typealias RTObjectPointer = UnsafeMutableRawPointer
-    public typealias TermPointer = UnsafeMutableRawPointer
-    public typealias InfoPointer = UnsafeMutableRawPointer
-    
     func throwError(message: String) throws -> Never {
         let location = rt.currentLocation ?? SourceLocation(at: "".startIndex, source: "")
         throw RuntimeError(description: message, location: location)

--- a/BushelRT/Built-in Functions/Builtin.swift
+++ b/BushelRT/Built-in Functions/Builtin.swift
@@ -32,32 +32,12 @@ final class Builtin {
         return newValue
     }
     
-    func isTruthy(_ object: RT_Object) -> Bool {
-        object.truthy
-    }
-    
-    func newReal(_ value: Double) -> RT_Object {
-        return RT_Real(value: value)
-    }
-    
-    func newInteger(_ value: Int64) -> RT_Object {
-        return RT_Integer(value: value)
-    }
-    
-    func newBoolean(_ value: Bool) -> RT_Object {
-        return RT_Boolean.withValue(value)
-    }
-    
-    func newString(_ cString: UnsafePointer<CChar>) -> RT_Object {
-        return RT_String(value: String(cString: cString))
-    }
-    
     func newConstant(_ typedUID: TypedTermUID) -> RT_Object {
         switch ConstantUID(typedUID) {
         case .true:
-            return newBoolean(true)
+            return RT_Boolean.withValue(true)
         case .false:
-            return newBoolean(false)
+            return RT_Boolean.withValue(false)
         default:
             return RT_Constant(value: rt.constant(forUID: typedUID))
         }
@@ -464,12 +444,6 @@ extension SwiftAutomation.Symbol {
             fatalError("invalid descriptor type for Symbol")
         }
     }
-    
-}
-
-internal class RT_Private_ArgumentRecord: RT_Object {
-    
-    var contents: [TypedTermUID : RT_Object] = [:]
     
 }
 

--- a/BushelRT/Errors.swift
+++ b/BushelRT/Errors.swift
@@ -97,6 +97,16 @@ public struct Uncoercible: LocalizedError {
     
 }
 
+public struct TypeObjectRequired: LocalizedError {
+    
+    public let object: RT_Object
+    
+    public var errorDescription: String? {
+        "A type object is required, but \(object) was provided"
+    }
+    
+}
+
 public struct MissingParameter: LocalizedError {
     
     public let command: CommandInfo

--- a/BushelRT/Runtime Objects/RT_Object.swift
+++ b/BushelRT/Runtime Objects/RT_Object.swift
@@ -386,12 +386,14 @@ import Bushel
     ///
     /// Cannot be overridden.
     /// `coerce(to:)` should be overridden to define coercions.
-    public final func coercing(to other: RT_Object) -> RT_Object? {
+    public final func coercing(to other: RT_Object) throws -> RT_Object {
         guard let type = (other as? RT_Class)?.value else {
-            // TODO: Throw here
-            return nil
+            throw TypeObjectRequired(object: other)
         }
-        return coerce(to: type)
+        guard let coerced = coerce(to: type) else {
+            throw Uncoercible(expectedType: type, object: self)
+        }
+        return coerced
     }
     
     /// Asks this object to perform the specified command.

--- a/BushelRT/Runtime.swift
+++ b/BushelRT/Runtime.swift
@@ -69,8 +69,6 @@ public class Runtime {
     public let topScript: RT_Script
     public var global: RT_Global!
     
-    private let objectPool = NSMapTable<RT_Object, NSNumber>(keyOptions: [.strongMemory, .objectPointerPersonality], valueOptions: .copyIn)
-    
     public var currentApplicationBundleID: String?
     
     public init(scriptName: String? = nil, currentApplicationBundleID: String? = nil) {
@@ -204,25 +202,6 @@ public class Runtime {
     
     public func command(forUID uid: TypedTermUID) -> CommandInfo {
         commandsByUID[uid] ?? add(forCommandUID: uid.uid)
-    }
-    
-    public func retain(_ object: RT_Object) {
-        var retainCount = objectPool.object(forKey: object)?.intValue ?? 0
-        retainCount += 1
-        objectPool.setObject(retainCount as NSNumber, forKey: object)
-    }
-    
-    public func release(_ object: RT_Object) {
-        guard var retainCount = objectPool.object(forKey: object)?.intValue else {
-            os_log("Warning: runtime object overreleased", log: log)
-            return
-        }
-        retainCount -= 1
-        if retainCount > 0 {
-            objectPool.setObject(retainCount as NSNumber, forKey: object)
-        } else {
-            objectPool.removeObject(forKey: object)
-        }
     }
     
 }

--- a/BushelRT/Runtime.swift
+++ b/BushelRT/Runtime.swift
@@ -320,7 +320,7 @@ public extension Runtime {
         case let .if_(condition, then, else_): // MARK: .if_
             let conditionValue = try runPrimary(condition, lastResult: lastResult, target: target)
             
-            if builtin.isTruthy(conditionValue) {
+            if conditionValue.truthy {
                 return try runPrimary(then, lastResult: lastResult, target: target)
             } else if let else_ = else_ {
                 return try runPrimary(else_, lastResult: lastResult, target: target)
@@ -329,7 +329,7 @@ public extension Runtime {
             }
         case .repeatWhile(let condition, let repeating): // MARK: .repeatWhile
             var repeatResult: RT_Object?
-            while builtin.isTruthy(try runPrimary(condition, lastResult: lastResult, target: target)) {
+            while try runPrimary(condition, lastResult: lastResult, target: target).truthy {
                 repeatResult = try runPrimary(repeating, lastResult: lastResult, target: target)
             }
             return try repeatResult ?? evaluate(lastResult, lastResult: lastResult, target: target)
@@ -338,7 +338,7 @@ public extension Runtime {
             
             var repeatResult: RT_Object?
             var count = 0
-            while builtin.isTruthy(builtin.binaryOp(.less, RT_Integer(value: count), timesValue)) {
+            while builtin.binaryOp(.less, RT_Integer(value: count), timesValue).truthy {
                 repeatResult = try runPrimary(repeating, lastResult: lastResult, target: target)
                 count += 1
             }
@@ -396,7 +396,7 @@ public extension Runtime {
                         )
                     },
                     uniquingKeysWith: {
-                        builtin.isTruthy(builtin.binaryOp(.greater, $1, $0)) ? $1 : $0
+                        builtin.binaryOp(.greater, $1, $0).truthy ? $1 : $0
                     }
                 )
             )
@@ -415,7 +415,7 @@ public extension Runtime {
         case .enumerator(let term as Term): // MARK: .enumerator
             return builtin.newConstant(term.typedUID)
         case .class_(let term as Term): // MARK: .class_
-            return builtin.newClass(term.typedUID)
+            return RT_Class(value: type(forUID: term.typedUID))
         case .set(let expression, to: let newValueExpression): // MARK: .set
             if case .variable(let variableTerm) = expression.kind {
                 let newValueExprValue = try runPrimary(newValueExpression, lastResult: lastResult, target: target)

--- a/BushelScript Editor/BushelScript Editor.xcodeproj/xcshareddata/xcschemes/BushelScript Editor.xcscheme
+++ b/BushelScript Editor/BushelScript Editor.xcodeproj/xcshareddata/xcschemes/BushelScript Editor.xcscheme
@@ -72,16 +72,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3C0566BD23135675004CDB1A"
-               BuildableName = "BushelScript EditorTests.xctest"
-               BlueprintName = "BushelScript EditorTests"
-               ReferencedContainer = "container:BushelScript Editor.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "3C0566C823135675004CDB1A"
                BuildableName = "BushelScript EditorUITests.xctest"
                BlueprintName = "BushelScript EditorUITests"

--- a/BushelScriptEnglish/EnglishParser.swift
+++ b/BushelScriptEnglish/EnglishParser.swift
@@ -19,6 +19,11 @@ public final class EnglishParser: BushelLanguage.SourceParser {
     public var awaitingExpressionEndKeywords: [Set<TermName>] = []
     public var sequenceEndTags: [TermName] = []
     
+    public var keywordsTraversalTable: TermNameTraversalTable = [:]
+    public var prefixOperatorsTraversalTable: TermNameTraversalTable = [:]
+    public var postfixOperatorsTraversalTable: TermNameTraversalTable = [:]
+    public var binaryOperatorsTraversalTable: TermNameTraversalTable = [:]
+    
     public init() {
     }
     


### PR DESCRIPTION
This branch was initially an experiment in removing multi-word user-defined term names. However, it seems that (depending on the situtation) some of the worst performance bottleneck previously was actually the poorly optimized keyword searching.

This PR introduces two term name search algorithms for keywords: "simple" and "complex". Simple is used for things like string delimiters, list delimiters, etc. Complex is used for keyword types that we might want to consist of multiple words, such as primary keywords and operators. _Note that regular defined term name searching is not yet optimized._ Keywords have a different search algo than defined terms because defined terms need to support qualification syntax (`a : b`), and the set of defined terms (the lexicon) changes pretty frequently, so we would have to add to / remove from the lookup table every time that happens (if we do something similar to the complex keyword algo).